### PR TITLE
fix(make-dev): include host configuration for running in codespaces/wsl.

### DIFF
--- a/makefile
+++ b/makefile
@@ -26,4 +26,4 @@ fix-lint:
 
 dev:
 	cd src/docusaurus
-	npx docusaurus start
+	npx docusaurus start --host 0.0.0.0


### PR DESCRIPTION
## What

- fix(make-dev): include host configuration for running in codespaces/wsl

## Why

- add the context for forwarding the port in wsl (host mode) or codespaces.

## How to test

- run a codespace and run `make dev`
